### PR TITLE
Keep original text formatting after chunking

### DIFF
--- a/src/chonky/__init__.py
+++ b/src/chonky/__init__.py
@@ -7,7 +7,7 @@ def split_into_chunks(lst, n):
 
 
 def split_text_into_even_chunks(tokenizer, text):
-    ids_plus = tokenizer(text, return_offsets_mapping=True, add_special_tokens=False)
+    ids_plus = tokenizer(text, truncation=False, add_special_tokens=False, return_offsets_mapping=True)
     token_offset_tups = ids_plus["offset_mapping"]
     offset_tup_chunks = split_into_chunks(token_offset_tups, n=tokenizer.model_max_length)
     # Map token chunks back to text chunks by using the start index of the first token and the end index of the last token

--- a/src/chonky/__init__.py
+++ b/src/chonky/__init__.py
@@ -7,10 +7,11 @@ def split_into_chunks(lst, n):
 
 
 def split_text_into_even_chunks(tokenizer, text):
-    ids = tokenizer(text, truncation=False, add_special_tokens=False)
-    ids = ids["input_ids"]
-    ids = split_into_chunks(ids, n=tokenizer.model_max_length)
-    chunks = (tokenizer.decode(chunk_ids) for chunk_ids in ids)
+    ids_plus = tokenizer(text, return_offsets_mapping=True, add_special_tokens=False)
+    token_offset_tups = ids_plus["offset_mapping"]
+    offset_tup_chunks = split_into_chunks(token_offset_tups, n=tokenizer.model_max_length)
+    # Map token chunks back to text chunks by using the start index of the first token and the end index of the last token
+    chunks = (text[offset_tup_chunk[0][0]:offset_tup_chunk[-1][1]] for offset_tup_chunk in offset_tup_chunks)
 
     return chunks
 


### PR DESCRIPTION
Hi, very cool project! 

I found a way to keep the original formatting of the text, by using the `return_offsets_mapping` parameter to get the exact index span of each token in the original text. After splitting the tokens into chunks, we can then use these spans to map each token chunk to the corresponding text chunk.