### PR TITLE
Optimize final chunking logic

### DIFF
--- a/src/chonky/__init__.py
+++ b/src/chonky/__init__.py
@@ -4,14 +4,10 @@ from transformers import AutoTokenizer, AutoModelForTokenClassification, pipelin
 def split_into_semantic_chunks(text, ners):
     begin_index = 0
 
-    for i, _c in enumerate(text):
-        for ner in ners:
-            if i == ner["end"]:
-                chunk = text[begin_index : ner["end"]]
-
-                yield chunk
-
-                begin_index = ner["end"]
+    for ner in ners:
+        chunk = text[begin_index : ner["end"]]
+        yield chunk
+        begin_index = ner["end"]
 
     yield text[begin_index:]
 


### PR DESCRIPTION
Currently, `split_into_semantic_chunks` iterates through the list of separator entities once for every character in the input text. This is costly, but luckily also not necessary. By removing the outer loop, one can achieve a significant speedup for free!